### PR TITLE
fix: update task-start-preflight trigger terms to avoid conflict with task-perform

### DIFF
--- a/skills/task-start-preflight/SKILL.md
+++ b/skills/task-start-preflight/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-start-preflight
-description: Prepare to work on a task. Use when user says "start task", "work on task", "begin task", "pick up task", "get started", "get started on", "let's do task", "do task", "tackle task", or any variation of starting work on a task.
+description: Prepare to work on a task. Use when user says "start task", "begin task", "pick up task", or similar.
 ---
 
 # Task Start Preflight


### PR DESCRIPTION
## Summary

Update trigger terms for `task-start-preflight` to avoid conflicts with `task-perform` from todu-skills.

## Changes

**Removed triggers:**
- "work on task"
- "get started"
- "get started on"
- "let's do task"
- "do task"
- "tackle task"

**Kept triggers:**
- "start task"
- "begin task"
- "pick up task"

## Rationale

- "start/begin" = preflight/preparation (task-start-preflight)
- "do/perform/execute/work on" = follow instructions (task-perform)

## Related

- Task #1337
- todu-skills Task #1336: Update task-perform trigger terms