### PR TITLE
fix: update task-close-preflight trigger terms to avoid conflict with task-update

### DIFF
--- a/skills/task-close-preflight/SKILL.md
+++ b/skills/task-close-preflight/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-close-preflight
-description: Verify work is complete before closing a task. Use before "close task", "complete task", "mark task as done", or similar.
+description: Verify work is complete before closing a task. Use when user says "close task", "complete task", "finish task", "verify and close", or similar.
 ---
 
 # Task Close Preflight


### PR DESCRIPTION
## Summary

Update trigger terms for `task-close-preflight` to avoid conflicts with `task-update` from todu-skills.

## Changes

**Removed:**
- "mark task as done"

**Added:**
- "finish task"
- "verify and close"

**Kept:**
- "close task"
- "complete task"

## Rationale

- "close/complete/finish" = preflight verification (task-close-preflight)
- "mark done", "set status" = direct action (task-update)

## Related

- Task #1339
- todu-skills Task #1338: Update task-update trigger terms