### PR TITLE
feat: enforce stable library versions only

### DIFF
--- a/skills/project-scaffold/templates/agents/go.md
+++ b/skills/project-scaffold/templates/agents/go.md
@@ -38,6 +38,15 @@ Key Makefile targets:
 
 Read the Makefile to understand available commands before starting work.
 
+## Dependencies
+
+When adding packages:
+- Use latest **STABLE** versions only
+- Reject canary/beta/alpha/rc versions unless user explicitly approves
+- Check for stable releases before adding dependencies
+
+Non-stable versions (canary, beta, alpha, rc) can have bugs or incomplete features. Always ask before using them.
+
 ## Task Lifecycle
 
 - **Starting**: ALWAYS run `task-start-preflight` skill first

--- a/skills/project-scaffold/templates/agents/python.md
+++ b/skills/project-scaffold/templates/agents/python.md
@@ -38,6 +38,15 @@ Key Makefile targets:
 
 Read the Makefile to understand available commands before starting work.
 
+## Dependencies
+
+When installing packages:
+- Use latest **STABLE** versions only
+- Reject canary/beta/alpha/rc versions unless user explicitly approves
+- Check PyPI for stable releases: `pip index versions <package>`
+
+Non-stable versions (canary, beta, alpha, rc) can have bugs or incomplete features. Always ask before using them.
+
 ## Task Lifecycle
 
 - **Starting**: ALWAYS run `task-start-preflight` skill first

--- a/skills/project-scaffold/templates/agents/rust.md
+++ b/skills/project-scaffold/templates/agents/rust.md
@@ -38,6 +38,15 @@ Key Makefile targets:
 
 Read the Makefile to understand available commands before starting work.
 
+## Dependencies
+
+When adding crates:
+- Use latest **STABLE** versions only
+- Reject canary/beta/alpha/rc versions unless user explicitly approves
+- Check crates.io for stable releases
+
+Non-stable versions (canary, beta, alpha, rc) can have bugs or incomplete features. Always ask before using them.
+
 ## Task Lifecycle
 
 - **Starting**: ALWAYS run `task-start-preflight` skill first

--- a/skills/project-scaffold/templates/agents/typescript.md
+++ b/skills/project-scaffold/templates/agents/typescript.md
@@ -38,6 +38,15 @@ Key Makefile targets:
 
 Read the Makefile to understand available commands before starting work.
 
+## Dependencies
+
+When installing packages:
+- Use latest **STABLE** versions only
+- Reject canary/beta/alpha/rc versions unless user explicitly approves
+- Verify stable version: `npm view <package> versions | grep -v '-'`
+
+Non-stable versions (canary, beta, alpha, rc) can have bugs or incomplete features. Always ask before using them.
+
 ## Task Lifecycle
 
 - **Starting**: ALWAYS run `task-start-preflight` skill first

--- a/skills/task-start-preflight/SKILL.md
+++ b/skills/task-start-preflight/SKILL.md
@@ -114,7 +114,27 @@ fi
 **Skip for docs-only tasks:**
 - If task title/labels indicate documentation-only work, skip this check
 
-### 6. Understand Context
+### 6. Check Runtime Versions
+
+Check that runtime environments are using stable versions (not canary/beta/alpha/rc):
+
+```bash
+# Check common runtimes
+node --version 2>/dev/null | grep -qE '(-canary|-beta|-alpha|-rc)' && echo "⚠️ Node: non-stable version"
+bun --version 2>/dev/null | grep -qE '(-canary|-beta|-alpha|-rc)' && echo "⚠️ Bun: non-stable version"
+```
+
+**If non-stable version detected:**
+- Warn: "⚠️ Runtime uses non-stable version: <version>"
+- Note potential issues: "Canary/beta versions may have bugs or missing features"
+- Ask: "Continue with non-stable runtime? [yes / no]"
+
+**Why this matters:**
+- Canary builds can have breaking bugs (e.g., bun:sqlite failures)
+- Beta/RC versions may have incomplete features
+- Stable versions are tested and reliable
+
+### 7. Understand Context
 
 **Check for related files mentioned in task:**
 - If task references specific files, verify they exist
@@ -126,7 +146,7 @@ fi
 todu task show <task-id> | grep "Source URL"
 ```
 
-### 7. Establish the Plan
+### 8. Establish the Plan
 
 Summarize for the user:
 


### PR DESCRIPTION
## Summary
Enforces use of stable library/runtime versions only. Non-stable versions (canary, beta, alpha, rc) require explicit user approval.

## Changes

### task-start-preflight
- Added step 6: Check Runtime Versions
- Detects non-stable versions in node/bun
- Warns user and asks for confirmation before proceeding

### AGENTS.md templates (all stacks)
- Added Dependencies section with stable version guidance
- TypeScript: `npm view <package> versions`
- Python: `pip index versions <package>`
- Go/Rust: Check respective package registries

## Problem Solved
Discovered when bun:sqlite failed due to Bun canary version (v1.3.5-canary). Canary/beta builds can have bugs or missing features.

Fixes #25
Task: #1354