### PR TITLE
fix: use todu note add --habit instead of todu habit comment

### DIFF
--- a/skills/habit-perform/SKILL.md
+++ b/skills/habit-perform/SKILL.md
@@ -13,8 +13,10 @@ Views a habit, follows the instructions in its description, and asks before chec
 1. View the habit: `todu habit show <id>`
 2. Read and understand the habit description
 3. Perform the habit
-4. Ask the user if they want to check in for today
-5. If yes, run `todu habit check <id>`
+4. Ask the user if they want to record a note about the session
+5. If yes, run `todu note add --habit <id> "<content>"`
+6. Ask the user if they want to check in for today
+7. If yes, run `todu habit check <id>`
 
 ## CLI Commands
 
@@ -22,6 +24,7 @@ Views a habit, follows the instructions in its description, and asks before chec
 # Habit flow
 
 todu habit show <id>
+todu note add --habit <id> "<content>"
 todu habit check <id>
 ```
 
@@ -33,11 +36,14 @@ todu habit check <id>
 
 1. Runs `todu habit show 15` to view details
 2. Follows instructions in the habit description
-3. Asks: "Check in habit #15 for today?" (Yes / No)
-4. If yes, runs `todu habit check 15`
+3. Asks: "Record a note about this session?" (Yes / No)
+4. If yes, runs `todu note add --habit 15 "Completed 10 min session"`
+5. Asks: "Check in habit #15 for today?" (Yes / No)
+6. If yes, runs `todu habit check 15`
 
 ## Notes
 
-- Ask the user before checking in a habit
+- Ask the user before recording a note or checking in a habit
+- Use `todu note add --habit <id> "<content>"` to record notes (not `todu habit comment`)
 - Use `task-perform` or `task-pipeline` for task requests
 - Use `habit-check` when the user only wants to check in or undo a check-in


### PR DESCRIPTION
## Summary

The habit-perform skill referenced a non-existent `todu habit comment` command for recording notes after performing a habit. Updated to use `todu note add --habit <id> <content>` which is the correct CLI command.

## Changes

- Added note-recording step to the process flow (step 4-5)
- Updated CLI Commands section with `todu note add` command
- Updated example to show note recording
- Added clarifying note about correct command

Closes task-84fe6a62