### PR TITLE
feat: use native habit tools in habit-perform

### DIFF
--- a/skills/habit-perform/SKILL.md
+++ b/skills/habit-perform/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: habit-perform
 description: Perform a habit by reading its details and optionally checking in for today. Use when user says "do habit #*", "perform habit #*", "handle habit #*", "work on habit #*", or similar. Do not use for task requests. (plugin:todu)
-allowed-tools: todu, Bash, Read, Write, Edit, AskUserQuestion
+allowed-tools: habit_show, habit_note_add, habit_check, Read, Write, Edit, AskUserQuestion
 ---
 
 # Perform Habit
@@ -10,20 +10,19 @@ Views a habit, follows the instructions in its description, and asks before chec
 
 ## Process
 
-1. View the habit: `todu habit show <id>`
+1. View the habit with `habit_show` using the habit ID
 2. Read and understand the habit description
 3. Perform the habit
-4. Ask the user if they want to check in for today
-5. If yes, run `todu habit check <id>`
+4. Ask the user if they want to record a note about the session
+5. If yes, run `habit_note_add` with the habit ID and note content
+6. Ask the user if they want to check in for today
+7. If yes, run `habit_check` with the habit ID
 
-## CLI Commands
+## Native Tools
 
-```bash
-# Habit flow
-
-todu habit show <id>
-todu habit check <id>
-```
+- `habit_show` to view habit details
+- `habit_note_add` to record a note about the session
+- `habit_check` to check in or toggle today's check-in
 
 ## Example
 
@@ -31,13 +30,16 @@ todu habit check <id>
 
 **User**: "Do habit 15"
 
-1. Runs `todu habit show 15` to view details
+1. Runs `habit_show` with `habitId: "15"` to view details
 2. Follows instructions in the habit description
-3. Asks: "Check in habit #15 for today?" (Yes / No)
-4. If yes, runs `todu habit check 15`
+3. Asks: "Record a note about this session?" (Yes / No)
+4. If yes, runs `habit_note_add` with `habitId: "15"` and `content: "Completed 10 min session"`
+5. Asks: "Check in habit #15 for today?" (Yes / No)
+6. If yes, runs `habit_check` with `habitId: "15"`
 
 ## Notes
 
-- Ask the user before checking in a habit
+- Ask the user before recording a note or checking in a habit
+- Use `habit_note_add` to record notes on habits
 - Use `task-perform` or `task-pipeline` for task requests
 - Use `habit-check` when the user only wants to check in or undo a check-in


### PR DESCRIPTION
## Summary
- replace todu CLI commands in habit-perform with native habit tools
- update the documented flow to use habit_show, habit_note_add, and habit_check
- remove the todu CLI dependency from allowed-tools

## Testing
- read back skills/habit-perform/SKILL.md and verified acceptance criteria manually