### PR TITLE
Refine skill trigger descriptions

### DIFF
--- a/skills/brave-search/SKILL.md
+++ b/skills/brave-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brave-search
-description: Web search and content extraction via Brave Search API. Use for searching documentation, facts, or any web content. Lightweight, no browser required.
+description: Web search and page extraction via Brave Search API. Use for docs, facts, current info, or page content. Do not use for interactive/authenticated browsing or UI testing.
 ---
 
 # Brave Search

--- a/skills/browser-tools/SKILL.md
+++ b/skills/browser-tools/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: browser-tools
-description: Interactive browser automation via Chrome DevTools Protocol. Use when you need to interact with web pages, test frontends, or when user interaction with a visible browser is required.
+description: Browser automation via Chrome DevTools Protocol. Use to inspect, click, test, or screenshot web pages. Do not use for simple search or static extraction.
 ---
 
 # Browser Tools

--- a/skills/dev-environment/SKILL.md
+++ b/skills/dev-environment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dev-environment
-description: Set up local development environment with process management (overmind). Use when asked to "set up dev environment", "create Makefile", or as part of project-init.
+description: Set up local dev-environment scaffolding with overmind templates. Use for dev setup, Makefile support, or project-init. Do not use for lint/test config.
 ---
 
 # Dev Environment

--- a/skills/electron-testing/SKILL.md
+++ b/skills/electron-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: electron-testing
-description: Test and interact with Electron desktop applications using Playwright via CDP (Chrome DevTools Protocol). Use when testing Electron apps, debugging UI issues, taking screenshots, verifying interactions, walking through manual test plans, or exercising Electron-based desktop applications. Trigger when user mentions "test electron app", "debug electron", "electron screenshot", "walk through the app", or references testing a desktop app built with Electron.
+description: Test and interact with Electron desktop apps using Playwright via CDP. Use for Electron UI testing, screenshots, debugging, or manual test walks. Do not use for ordinary web apps.
 ---
 
 # Electron Testing

--- a/skills/habit-perform/SKILL.md
+++ b/skills/habit-perform/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: habit-perform
-description: Perform a habit by reading its details and optionally checking in for today. Use when user says "do habit #*", "perform habit #*", "handle habit #*", "work on habit #*", or similar. Do not use for task requests. (plugin:todu)
+description: Perform a Todu habit and optionally check it in. Use for "do/perform/handle/work on habit". Do not use for task requests. (plugin:todu)
 allowed-tools: habit_show, habit_note_add, habit_check, Read, Write, Edit, AskUserQuestion
 ---
 

--- a/skills/nextactions/SKILL.md
+++ b/skills/nextactions/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: nextactions
-description: Show next actions to work on. Use when user says "next actions", "what's next", "what should I work on", or similar. (plugin:todu)
-allowed-tools: todu
+description: Show prioritized Todu next actions. Use when user asks "next actions", "what's next", or "what should I work on". Do not use for general task search. (plugin:todu)
 ---
 
 # Next Actions
@@ -9,16 +8,14 @@ allowed-tools: todu
 Shows tasks that need attention by querying:
 1. Tasks with status `inprogress`
 2. Tasks with status `active` and priority `high`
-3. Active or in-progress tasks in the `Inbox` project
-4. Active tasks due or scheduled today
-5. Active overdue tasks
+3. Active tasks due or scheduled today
+4. Active overdue tasks
 
 ## CLI Commands
 
 ```bash
 todu task list --status inprogress
 todu task list --status active --priority high
-todu task list --project Inbox --status active,inprogress
 todu task list --status active --today
 todu task list --status active --overdue
 ```

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-review
-description: Run pull request review, verify artifacts, report outcome, and stop at the human merge gate. Use when user says "request review", "review PR", "get this reviewed", or similar.
+description: Run PR review, verify artifacts, report outcome, and stop at the human merge gate. Use for "request review", "review PR", or "get this reviewed". Do not merge.
 ---
 
 # PR Review

--- a/skills/project-init/SKILL.md
+++ b/skills/project-init/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-init
-description: Initialize a new project end-to-end. Creates repo, scaffolds files, sets up quality tooling and dev environment. Use when asked to "create a new project", "init project", "start a new app", or similar.
+description: Initialize a project end-to-end: repo, registration, scaffold, quality tooling, and dev environment. Use for new project/app setup. Do not use for one-off setup changes.
 ---
 
 # Project Init

--- a/skills/project-scaffold/SKILL.md
+++ b/skills/project-scaffold/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-scaffold
-description: Generate basic project scaffolding files (README, LICENSE, .gitignore, AGENTS.md, docs/, PR template). Use when setting up a new project or asked to "scaffold project", "create project files", or similar.
+description: Generate foundational files: README, LICENSE, .gitignore, AGENTS.md, docs, and PR template. Use for project scaffolding. Do not use for lint/test or dev-env setup.
 ---
 
 # Project Scaffold

--- a/skills/quality-tooling/SKILL.md
+++ b/skills/quality-tooling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quality-tooling
-description: Set up linting, formatting, testing, and pre-commit hooks for a project. Use when asked to "add linting", "set up quality tools", "configure eslint", "add pre-commit hooks", or similar.
+description: Set up linting, formatting, testing, and pre-commit hooks. Use for quality tooling requests such as ESLint, Ruff, Vitest, or pre-commit. Do not use for dev-server setup.
 ---
 
 # Quality Tooling

--- a/skills/repo-create/SKILL.md
+++ b/skills/repo-create/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: repo-create
-description: Create a remote repository and clone it locally. Use when asked to "create a repo", "new repository", "init repo", or as part of project-init.
+description: Create a remote repository and clone it locally. Use for explicit new repo requests or project-init. Do not use for local-only scaffolding.
 ---
 
 # Repo Create

--- a/skills/task-authoring/SKILL.md
+++ b/skills/task-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-authoring
-description: Draft and refine task titles and structured markdown task content.
+description: Draft and refine task titles and structured markdown descriptions. Use before creating or updating task content. Does not create backend task records.
 ---
 
 # Task Authoring

--- a/skills/task-close-gate/SKILL.md
+++ b/skills/task-close-gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-close-gate
-description: Verify a task is ready to close. Use when user says "close task", "complete task", "finish task", or "verify and close".
+description: Verify a Todu task is ready to close against acceptance criteria. Use for "close task", "complete task", or "verify and close". Do not use to start work.
 ---
 
 # Task Close Gate

--- a/skills/task-comment-authoring/SKILL.md
+++ b/skills/task-comment-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-comment-authoring
-description: Draft and refine structured markdown task notes and comments.
+description: Draft and refine structured markdown task notes/comments. Use before posting task updates, blockers, completions, or review notes. Does not post comments.
 ---
 
 # Task Comment Authoring

--- a/skills/task-perform/SKILL.md
+++ b/skills/task-perform/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-perform
-description: Start working on a task and follow its instructions. Use when user says "do task #*", "perform task #*", "execute task #*", "handle task #*", or similar. Do not use for habit requests or the broader pickup-task pipeline flow. (plugin:todu)
+description: Start and perform a Todu task. Use for "do/perform/execute/handle task". Do not use for habits or the full pickup-task pipeline. (plugin:todu)
 allowed-tools: todu, Bash, Read, Write, Edit, AskUserQuestion
 ---
 

--- a/skills/task-pipeline/SKILL.md
+++ b/skills/task-pipeline/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-pipeline
-description: Use when user says "pickup task <task-id|task-name>", "get started on task <task-id|task-name>", or "work on task <task-id|task-name>".
+description: Run the full gated coding-task pickup flow. Use for "pickup task", "get started on task", or "work on task". Do not use for simple show/start/done task actions.
 ---
 
 # task-pipeline

--- a/skills/task-start-preflight/SKILL.md
+++ b/skills/task-start-preflight/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-start-preflight
-description: Verify a task is ready to be worked on. Use when user says "start preflight", "run preflight", "task preflight", or similar.
+description: Verify a Todu task is ready to be worked on. Use for "start preflight", "run preflight", or pipeline readiness checks. Do not implement the task.
 ---
 
 # Task Start Preflight

--- a/skills/tmux/SKILL.md
+++ b/skills/tmux/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tmux
-description: Orchestrate isolated tmux sessions for interactive agent work and command execution. Use when user asks to run something in tmux or says "use a sub-agent".
+description: Orchestrate isolated tmux sessions for commands or sub-agents. Use when user asks for tmux, visible sessions, detached sessions, or sub-agents. Do not use for ordinary shell commands.
 ---
 
 # tmux Skill


### PR DESCRIPTION
## Summary

- Tighten local skill frontmatter descriptions with concise use signals
- Add targeted negative triggers for overlapping skill families
- Remove `allowed-tools` metadata from `nextactions` and include the existing Inbox query cleanup

## Verification

- `rg` check for vague description phrases (`helps with`, `any task`, `or similar`)
- `git diff --check`

Task: task-56a64965