### PR TITLE
Use Chromium for browser-tools

### DIFF
--- a/skills/browser-tools/.gitignore
+++ b/skills/browser-tools/.gitignore
@@ -1,5 +1,6 @@
-# Headless Chrome profile (copy of user's Chrome profile)
+# Browser profile data
 .headless-profile/
+chromium-profile/
 
 # Node modules
 node_modules/

--- a/skills/browser-tools/SKILL.md
+++ b/skills/browser-tools/SKILL.md
@@ -5,7 +5,7 @@ description: Browser automation via Chrome DevTools Protocol. Use to inspect, cl
 
 # Browser Tools
 
-Chrome DevTools Protocol tools for agent-assisted web automation. These tools connect to Chrome running on `:9222` with remote debugging enabled.
+Chrome DevTools Protocol tools for agent-assisted web automation. These tools connect to Chromium running on `:9222` with remote debugging enabled.
 
 ## Setup
 
@@ -16,14 +16,26 @@ cd {baseDir}
 npm install
 ```
 
-## Start Chrome
+## Start Chromium
 
 ```bash
-{baseDir}/browser-start.js              # Fresh profile
-{baseDir}/browser-start.js --profile    # Copy user's profile (cookies, logins)
+{baseDir}/browser-start.js              # Isolated Chromium profile under ~/.cache/browser-tools
+{baseDir}/browser-start.js --profile    # Persistent Chromium profile under ~/.config/browser-tools
 ```
 
-Launch Chrome with remote debugging on `:9222`. Use `--profile` to preserve user's authentication state.
+Launch Chromium with remote debugging on `:9222`. Existing tools connect to `http://localhost:9222` and work with the started Chromium instance.
+
+`browser-start.js` looks for Chromium in this order:
+
+1. `BROWSER_TOOLS_CHROMIUM_PATH`
+2. `CHROMIUM_PATH`
+3. `PUPPETEER_EXECUTABLE_PATH`
+4. Common platform paths such as `/Applications/Chromium.app/Contents/MacOS/Chromium`, `/usr/bin/chromium`, `/usr/bin/chromium-browser`, `/snap/bin/chromium`, and Windows Chromium install locations
+5. `chromium` or `chromium-browser` on `PATH`
+
+If Chromium is not found, `browser-start.js` installs Puppeteer-managed Chromium with `puppeteer browsers install chromium@latest`. Set `BROWSER_TOOLS_SKIP_CHROMIUM_INSTALL=1` to disable automatic installation and receive install instructions instead. Set `BROWSER_TOOLS_USER_DATA_DIR=/path/to/profile` to override the profile directory.
+
+The tool no longer copies the Google Chrome profile. Use the Chromium profile started by this tool, or pass `BROWSER_TOOLS_USER_DATA_DIR` to reuse an existing Chromium-compatible user data directory.
 
 ## Navigate
 

--- a/skills/browser-tools/browser-start.js
+++ b/skills/browser-tools/browser-start.js
@@ -1,18 +1,32 @@
 #!/usr/bin/env node
 
-import { spawn, execSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readdirSync, statSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import puppeteer from "puppeteer-core";
 
-const useProfile = process.argv[2] === "--profile";
+const args = process.argv.slice(2);
+const useProfile = args.includes("--profile");
 
-if (process.argv[2] && process.argv[2] !== "--profile") {
+if (args.some((arg) => arg !== "--profile")) {
 	console.log("Usage: browser-start.js [--profile]");
 	console.log("\nOptions:");
-	console.log("  --profile  Copy your default Chrome profile (cookies, logins)");
+	console.log("  --profile  Use a persistent Chromium profile directory");
+	console.log("\nEnvironment:");
+	console.log("  BROWSER_TOOLS_CHROMIUM_PATH  Absolute path to the Chromium executable");
+	console.log("  CHROMIUM_PATH                Fallback Chromium executable override");
+	console.log("  PUPPETEER_EXECUTABLE_PATH    Fallback executable override");
+	console.log("  BROWSER_TOOLS_USER_DATA_DIR  Override the Chromium user data directory");
+	console.log("  BROWSER_TOOLS_SKIP_CHROMIUM_INSTALL=1  Disable automatic Chromium install");
 	process.exit(1);
 }
 
-const SCRAPING_DIR = `${process.env.HOME}/.cache/browser-tools`;
+const SCRIPT_DIR = fileURLToPath(new URL(".", import.meta.url));
+const CACHE_DIR = `${process.env.HOME}/.cache/browser-tools`;
+const PROFILE_DIR =
+	process.env.BROWSER_TOOLS_USER_DATA_DIR ||
+	(useProfile ? `${process.env.HOME}/.config/browser-tools/chromium-profile` : `${CACHE_DIR}/chromium-profile`);
 
 // Check if already running on :9222
 try {
@@ -21,48 +35,197 @@ try {
 		defaultViewport: null,
 	});
 	await browser.disconnect();
-	console.log("✓ Chrome already running on :9222");
+	console.log("✓ Chromium-compatible browser already running on :9222");
 	process.exit(0);
 } catch {}
 
-// Setup profile directory
-execSync(`mkdir -p "${SCRAPING_DIR}"`, { stdio: "ignore" });
-
-// Remove SingletonLock to allow new instance
-try {
-	execSync(`rm -f "${SCRAPING_DIR}/SingletonLock" "${SCRAPING_DIR}/SingletonSocket" "${SCRAPING_DIR}/SingletonCookie"`, { stdio: "ignore" });
-} catch {}
-
-if (useProfile) {
-	console.log("Syncing profile...");
-	execSync(
-		`rsync -a --delete \
-			--exclude='SingletonLock' \
-			--exclude='SingletonSocket' \
-			--exclude='SingletonCookie' \
-			--exclude='*/Sessions/*' \
-			--exclude='*/Current Session' \
-			--exclude='*/Current Tabs' \
-			--exclude='*/Last Session' \
-			--exclude='*/Last Tabs' \
-			"${process.env.HOME}/Library/Application Support/Google/Chrome/" "${SCRAPING_DIR}/"`,
-		{ stdio: "pipe" },
-	);
+function isExecutablePath(path) {
+	if (!path) return false;
+	try {
+		return existsSync(path) && statSync(path).isFile();
+	} catch {
+		return false;
+	}
 }
 
-// Start Chrome with flags to force new instance
+function isUsableChromiumExecutable(path) {
+	if (!isExecutablePath(path)) return false;
+
+	const result = spawnSync(path, ["--version"], {
+		encoding: "utf8",
+		timeout: 5000,
+	});
+
+	if (result.status !== 0) return false;
+	return /Chrom(e|ium)|HeadlessChrome/i.test(`${result.stdout || ""}\n${result.stderr || ""}`);
+}
+
+function findCommand(command) {
+	const result =
+		process.platform === "win32"
+			? spawnSync("where", [command], { encoding: "utf8" })
+			: spawnSync("sh", ["-lc", `command -v ${command}`], { encoding: "utf8" });
+
+	if (result.status !== 0) return null;
+	return result.stdout.trim().split(/\r?\n/).find(Boolean) || null;
+}
+
+function puppeteerCacheChromiumPaths() {
+	const cacheDir = `${process.env.HOME}/.cache/puppeteer/chromium`;
+	if (!existsSync(cacheDir)) return [];
+
+	let builds;
+	try {
+		builds = readdirSync(cacheDir, { withFileTypes: true })
+			.filter((entry) => entry.isDirectory())
+			.map((entry) => entry.name)
+			.sort()
+			.reverse();
+	} catch {
+		return [];
+	}
+
+	return builds.flatMap((build) => {
+		const buildDir = join(cacheDir, build);
+		if (process.platform === "darwin") {
+			return [join(buildDir, "chrome-mac", "Chromium.app", "Contents", "MacOS", "Chromium")];
+		}
+		if (process.platform === "linux") {
+			return [join(buildDir, "chrome-linux", "chrome"), join(buildDir, "chrome-linux64", "chrome")];
+		}
+		if (process.platform === "win32") {
+			return [join(buildDir, "chrome-win", "chrome.exe"), join(buildDir, "chrome-win64", "chrome.exe")];
+		}
+		return [];
+	});
+}
+
+function commonChromiumPaths() {
+	const paths = [...puppeteerCacheChromiumPaths()];
+
+	if (process.platform === "darwin") {
+		paths.push(
+			"/Applications/Chromium.app/Contents/MacOS/Chromium",
+			`${process.env.HOME}/Applications/Chromium.app/Contents/MacOS/Chromium`,
+		);
+	} else if (process.platform === "linux") {
+		paths.push(
+			"/usr/bin/chromium",
+			"/usr/bin/chromium-browser",
+			"/usr/local/bin/chromium",
+			"/snap/bin/chromium",
+		);
+	} else if (process.platform === "win32") {
+		const localAppData = process.env.LOCALAPPDATA;
+		const programFiles = process.env.ProgramFiles;
+		const programFilesX86 = process.env["ProgramFiles(x86)"];
+		paths.push(
+			localAppData && join(localAppData, "Chromium", "Application", "chrome.exe"),
+			programFiles && join(programFiles, "Chromium", "Application", "chrome.exe"),
+			programFilesX86 && join(programFilesX86, "Chromium", "Application", "chrome.exe"),
+		);
+	}
+
+	return paths.filter(Boolean);
+}
+
+function resolveChromiumExecutable() {
+	const configuredPaths = [
+		process.env.BROWSER_TOOLS_CHROMIUM_PATH,
+		process.env.CHROMIUM_PATH,
+		process.env.PUPPETEER_EXECUTABLE_PATH,
+	];
+
+	for (const path of configuredPaths) {
+		if (isUsableChromiumExecutable(path)) return path;
+	}
+
+	for (const path of commonChromiumPaths()) {
+		if (isUsableChromiumExecutable(path)) return path;
+	}
+
+	for (const command of ["chromium", "chromium-browser"]) {
+		const path = findCommand(command);
+		if (isUsableChromiumExecutable(path)) return path;
+	}
+
+	return null;
+}
+
+function puppeteerCliPath() {
+	const executable = process.platform === "win32" ? "puppeteer.cmd" : "puppeteer";
+	const localPath = join(SCRIPT_DIR, "node_modules", ".bin", executable);
+	return isExecutablePath(localPath) ? localPath : null;
+}
+
+function installChromium() {
+	if (process.env.BROWSER_TOOLS_SKIP_CHROMIUM_INSTALL === "1") {
+		return null;
+	}
+
+	console.log("Chromium not found; installing Puppeteer-managed Chromium...");
+
+	const localCli = puppeteerCliPath();
+	const command = localCli || "npm";
+	const installArgs = localCli
+		? ["browsers", "install", "chromium@latest"]
+		: ["exec", "--", "puppeteer", "browsers", "install", "chromium@latest"];
+
+	const result = spawnSync(command, installArgs, {
+		cwd: SCRIPT_DIR,
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+
+	const output = `${result.stdout || ""}\n${result.stderr || ""}`.trim();
+	if (result.status !== 0) {
+		if (output) console.error(output);
+		return null;
+	}
+
+	if (output) console.log(output);
+
+	const executablePath = output
+		.split(/\r?\n/)
+		.map((line) => line.match(/^chromium@\S+\s+(.+)$/)?.[1])
+		.find(Boolean);
+
+	return isUsableChromiumExecutable(executablePath) ? executablePath : resolveChromiumExecutable();
+}
+
+const chromiumExecutable = resolveChromiumExecutable() || installChromium();
+
+if (!chromiumExecutable) {
+	console.error("✗ Chromium executable not found");
+	console.error("  Install Chromium or run:");
+	console.error("    cd \"%s\" && npm exec -- puppeteer browsers install chromium@latest", SCRIPT_DIR);
+	console.error("  Or set BROWSER_TOOLS_CHROMIUM_PATH=/absolute/path/to/chromium");
+	process.exit(1);
+}
+
+// Setup profile directory
+mkdirSync(PROFILE_DIR, { recursive: true });
+
+// Remove singleton files to allow a new isolated Chromium instance.
+for (const filename of ["SingletonLock", "SingletonSocket", "SingletonCookie"]) {
+	try {
+		unlinkSync(join(PROFILE_DIR, filename));
+	} catch {}
+}
+
+// Start Chromium with flags to force a new instance and expose CDP on :9222.
 spawn(
-	"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+	chromiumExecutable,
 	[
 		"--remote-debugging-port=9222",
-		`--user-data-dir=${SCRAPING_DIR}`,
+		`--user-data-dir=${PROFILE_DIR}`,
 		"--no-first-run",
 		"--no-default-browser-check",
 	],
 	{ detached: true, stdio: "ignore" },
 ).unref();
 
-// Wait for Chrome to be ready
+// Wait for Chromium to be ready
 let connected = false;
 for (let i = 0; i < 30; i++) {
 	try {
@@ -79,8 +242,9 @@ for (let i = 0; i < 30; i++) {
 }
 
 if (!connected) {
-	console.error("✗ Failed to connect to Chrome");
+	console.error("✗ Failed to connect to Chromium on :9222");
 	process.exit(1);
 }
 
-console.log(`✓ Chrome started on :9222${useProfile ? " with your profile" : ""}`);
+console.log(`✓ Chromium started on :9222 using ${chromiumExecutable}`);
+console.log(`  Profile: ${PROFILE_DIR}`);


### PR DESCRIPTION
## Summary
- Replace the hard-coded Google Chrome launch path with Chromium resolution from env overrides, Puppeteer cache, common platform paths, or PATH
- Install Puppeteer-managed Chromium automatically when no usable Chromium executable is found
- Stop copying the Google Chrome profile and document Chromium profile/configuration behavior

## Verification
- node --check on all browser-tools scripts
- BROWSER_TOOLS_SKIP_CHROMIUM_INSTALL=1 ./browser-start.js
- ./browser-nav.js about:blank
- ./browser-eval.js 'navigator.userAgent'

Task: task-b8c43556