### PR TITLE
Bound pr-review tmux completion behavior

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -49,6 +49,8 @@ To test the full review flow:
    - Review comment is posted to the task via `task-comment-create`
    - Agent reports review outcome and waits for explicit merge approval
 
+When testing through the tmux sub-agent wrapper, use a small PR and the wrapper's 120-second timeout. Verify that the review follows the bounded checklist, uses `task-comment-authoring` only for concise artifact drafting, posts both required comments, emits the marker-delimited `PR Review Status`, signals completion immediately, and does not continue with extra exploration after the verdict.
+
 ## Automated Testing
 
 TODO: Add automated tests for skills.

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -12,6 +12,18 @@ Review a PR and stop before merge.
 - PR number
 - task ID (required)
 
+## Bounded Execution Contract
+
+Complete the review with this short checklist only:
+
+1. Validate required inputs.
+2. Detect the PR host.
+3. Run the matching host worker.
+4. Validate required worker result fields and artifacts.
+5. Report the outcome and stop at the merge gate.
+
+Do not broaden the review after the worker returns a verdict. Do not reread unrelated project context, rerun checks, or continue exploratory reasoning after required artifacts are posted.
+
 ## Steps
 
 1. Validate task ID is provided.
@@ -35,6 +47,12 @@ Review a PR and stop before merge.
 - Never merge in this skill.
 - Never claim completion while required artifacts are missing.
 - Do not phrase required next steps as optional.
+- Avoid sub-skill calls except the explicitly required task/comment tooling used to post artifacts and `task-comment-authoring` when drafting structured review/task comments.
+- After the verdict is determined and required artifacts are posted, do not run additional checks or broad rereads.
+
+## Tmux Completion Rule
+
+When this skill runs inside the tmux sub-agent wrapper, emit the final `PR Review Status` output between the wrapper's result markers and signal completion immediately after posting required artifacts. No additional commentary, verification, or exploration may follow the marker-delimited result.
 
 ## Output Contract
 

--- a/skills/pr-review/pr-fj-review.md
+++ b/skills/pr-review/pr-fj-review.md
@@ -9,14 +9,18 @@ Review Forgejo PR content and post review artifacts.
 
 ## Procedure
 
-1. Validate PR exists and is open, then load context:
+1. Validate PR exists and is open, then load only required PR context:
    - `fj pr view <number>`
    - require open state
    - `fj pr view <number> diff`
 2. Follow shared review logic in `./pr-review-common.md`.
-3. Post structured PR review comment:
+3. Draft the structured task-facing review summary with `task-comment-authoring` before posting artifact content.
+4. Post structured PR review comment:
    - `fj pr comment <number> --body-file <review-file>`
-4. Add matching task review comment via `task-comment-create`.
+5. Add matching task review comment via `task-comment-create`.
+6. Emit the required worker result immediately and stop.
+
+Do not inspect unrelated repository files or rerun broad checks after the verdict is determined.
 
 ## Output Contract (Required)
 

--- a/skills/pr-review/pr-gh-review.md
+++ b/skills/pr-review/pr-gh-review.md
@@ -9,14 +9,18 @@ Review GitHub PR content and post review artifacts.
 
 ## Procedure
 
-1. Validate PR exists and is open, then load context:
+1. Validate PR exists and is open, then load only required PR context:
    - `gh pr view <number> --json number,title,body,state`
    - require `state=OPEN`
    - `gh pr diff <number>`
 2. Follow shared review logic in `./pr-review-common.md`.
-3. Post structured PR review comment:
+3. Draft the structured task-facing review summary with `task-comment-authoring` before posting artifact content.
+4. Post structured PR review comment:
    - `gh pr comment <number> --body-file <review-file>`
-4. Add matching task review comment via `task-comment-create`.
+5. Add matching task review comment via `task-comment-create`.
+6. Emit the required worker result immediately and stop.
+
+Do not inspect unrelated repository files or rerun broad checks after the verdict is determined.
 
 ## Output Contract (Required)
 

--- a/skills/pr-review/pr-review-common.md
+++ b/skills/pr-review/pr-review-common.md
@@ -8,6 +8,17 @@ Shared review logic for all hosts.
 - PR title/body
 - PR diff
 
+## Bounded Checklist
+
+1. Load task details once with `task-show` using the provided task ID.
+2. Extract task objective and acceptance criteria from the task description.
+3. Compare the PR diff against each acceptance criterion.
+4. Check only review-relevant quality concerns.
+5. Decide exactly one outcome.
+6. Prepare required artifact content.
+
+Stop once the outcome and artifact content are ready. Do not reread broad context, revisit settled criteria, or continue exploratory checks after choosing the verdict.
+
 ## Procedure
 
 1. Load task details via `task-show` using the provided task ID.
@@ -35,7 +46,7 @@ Shared review logic for all hosts.
 
 ## Required Review Content
 
-Review comment content must include:
+Use `task-comment-authoring` when drafting the task-facing review summary. Review comment content must include:
 - summary
 - acceptance criteria checklist with per-criterion status
 - blocking issues (if any)


### PR DESCRIPTION
## Summary
- Add a bounded execution contract to the pr-review skill
- Require immediate worker/result completion after posting artifacts
- Preserve task-comment-authoring usage for structured review summaries
- Document tmux wrapper completion expectations

## Verification
- python3 markdown readability smoke check
- rg contract checks for bounded execution, tmux completion, authoring usage, and immediate worker result

Task: task-ddde0864