### PR TITLE
Bound task close-gate tmux behavior

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -51,6 +51,19 @@ To test the full review flow:
 
 When testing through the tmux sub-agent wrapper, use a small PR and the wrapper's 120-second timeout. Verify that the review follows the bounded checklist, uses `task-comment-authoring` only for concise artifact drafting, posts both required comments, emits the marker-delimited `PR Review Status`, signals completion immediately, and does not continue with extra exploration after the verdict.
 
+### task-close-gate Skill
+
+To test close-gate behavior:
+
+1. Use a task with clear acceptance criteria and existing completion evidence in task comments or a referenced merged PR.
+2. Run: `verify and close task #<task-id>`.
+3. Verify:
+   - Each acceptance criterion is marked `met`, `partial`, or `missing` with explicit evidence
+   - The task is marked done only when all criteria are met
+   - A closing task comment is posted via `task-comment-create`
+
+When testing through the tmux sub-agent wrapper, use the wrapper's 120-second timeout. Verify that the close gate follows the bounded checklist, uses only bounded evidence sources, emits the marker-delimited close-gate result, signals completion immediately after the closing update or `BLOCKED` decision, and does not invoke unrelated skills or continue exploratory checks.
+
 ## Automated Testing
 
 TODO: Add automated tests for skills.

--- a/skills/task-close-gate/SKILL.md
+++ b/skills/task-close-gate/SKILL.md
@@ -11,27 +11,53 @@ Minimal closure gate for one task.
 
 - task ID (required)
 
+## Bounded Execution Contract
+
+Complete the close gate with this short checklist only:
+
+1. Load task details once.
+2. Extract acceptance criteria.
+3. Gather concise evidence from already-available artifacts.
+4. Decide `READY` or `BLOCKED`.
+5. If `READY`, post the closing comment and mark the task done.
+6. Emit the close-gate result and stop.
+
+If evidence is not found after the bounded checks below, return `BLOCKED` instead of broadening the search.
+
 ## Steps
 
 1. Load task details via `task-show`.
 2. Extract acceptance criteria from the task description.
-3. Evaluate each acceptance criterion with explicit evidence.
+3. Gather concise evidence from bounded sources only:
+   - recent task comments,
+   - referenced PR or merge status already present in task comments,
+   - current branch/commit status when the user explicitly asked to verify a merged branch,
+   - files directly named by the task, PR, or comments.
+4. Evaluate each acceptance criterion with explicit evidence.
    - status per criterion: `met` | `partial` | `missing`
    - do not assume evidence
-4. Determine readiness.
+5. Determine readiness.
    - all criteria `met` => `READY`
    - any `partial`/`missing` => `BLOCKED`
-5. Prepare a closing summary comment.
-6. If status is `READY`:
-   - close task
+6. Prepare a closing summary comment.
+7. If status is `READY`:
    - add closing summary comment via `task-comment-create`
+   - close task
    If status is `BLOCKED`, stop and report issues.
+8. Emit the required output and stop immediately.
 
 ## Rules
 
 - Do not close a task with incomplete criteria.
 - Keep checks focused on acceptance criteria and closure readiness.
 - Do not run stack-specific verification commands here (tests/log scraping/CI checks).
+- Do not invoke unrelated skills such as `pr-review`; use existing review artifacts as evidence instead.
+- Do not reread broad repository context, inspect unrelated files, or continue exploratory checks after each criterion has evidence.
+- Do not add commentary after the required output.
+
+## Tmux Completion Rule
+
+When this skill runs inside the tmux sub-agent wrapper, emit the final close-gate output between the wrapper's result markers and signal completion immediately after the closing comment/status update or `BLOCKED` decision. No additional commentary, verification, or exploration may follow the marker-delimited result.
 
 ## Output Template
 


### PR DESCRIPTION
## Summary
- Add a bounded execution contract to task-close-gate
- Limit close-gate evidence gathering to concise known artifacts
- Forbid unrelated skill calls and broad exploratory checks during closure
- Document tmux wrapper completion expectations for close-gate

## Verification
- python3 markdown readability smoke check
- rg contract checks for bounded execution, tmux completion, and unrelated-skill guard

Context: follow-up from task-ddde0864 close-gate timeout